### PR TITLE
Handle grpc headers in error path.

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,7 +4,8 @@ export class GrpcError extends Error {
   constructor(
     public error: string,
     public code?: number,
-    public trailers?: GrpcMetadata
+    public trailers?: GrpcMetadata,
+    public headers?: GrpcMetadata
   ) {
     super(error);
   }


### PR DESCRIPTION
Right now the grpc headers are ignored but they contain useful information even for grpc errors. This change augments the error with a headers field and fills it in with the grpc headers if they are available. The current change is only for UnaryCalls.